### PR TITLE
Add watchdog and apscheduler to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ numpy
 torch
 pytest
 requests
+watchdog
+apscheduler
+pgsql


### PR DESCRIPTION
## Summary
- extend root requirements with watchdog, apscheduler and pgsql

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68414fae5fb883218e57605838b594ad