### PR TITLE
Refactor self-improve threshold

### DIFF
--- a/src/self_improve.py
+++ b/src/self_improve.py
@@ -1,30 +1,35 @@
 import time
 import threading
+import yaml
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 from trainer import Trainer
 
 class MemoryHandler(FileSystemEventHandler):
     """
-    Watches the memory_store folder. When a new JSON appears,
-    checks if memory size exceeds threshold and calls fine-tune.
+    Watches memory_store/. When a new file appears, checks if
+    memory size ≥ threshold (from config) and triggers fine-tune.
     """
-    def __init__(self, trainer: Trainer, threshold: int = 100):
+    def __init__(self, trainer: Trainer, threshold: int):
         super().__init__()
         self.trainer = trainer
         self.threshold = threshold
 
     def on_created(self, event):
-        # Called when a new file is created in memory_store/
         memory_buffer = self.trainer.memory.buffer
         if len(memory_buffer) >= self.threshold:
             print(f"[SelfImprove] Memory size {len(memory_buffer)} ≥ {self.threshold}. Triggering fine-tune.")
             self.trainer.fine_tune()
 
-def start_self_improvement(config_path: str = "configs/default.yaml", threshold: int = 100):
+def start_self_improvement(config_path: str = "configs/default.yaml"):
     """
-    Launches a watchdog observer on memory_store/ and runs indefinitely in a background thread.
+    Launch a watcher that triggers Trainer.fine_tune() when memory reaches threshold.
     """
+    # Load the same config file to retrieve threshold
+    with open(config_path, "r") as f:
+        cfg = yaml.safe_load(f)
+
+    threshold = cfg.get("trainer", {}).get("self_improve_threshold", 100)
     trainer = Trainer(config_path=config_path)
     memory_path = trainer.memory.storage_path
 
@@ -33,7 +38,7 @@ def start_self_improvement(config_path: str = "configs/default.yaml", threshold:
     observer.schedule(event_handler, path=memory_path, recursive=False)
     observer.start()
 
-    print(f"[SelfImprove] Monitoring '{memory_path}' for new memory files.")
+    print(f"[SelfImprove] Monitoring '{memory_path}' with threshold {threshold}.")
     try:
         while True:
             time.sleep(1)
@@ -42,5 +47,4 @@ def start_self_improvement(config_path: str = "configs/default.yaml", threshold:
     observer.join()
 
 if __name__ == "__main__":
-    # If someone runs this script directly, start the watcher
     start_self_improvement()


### PR DESCRIPTION
## Summary
- read self-improve threshold from config
- refactor self_improve.py to load trainer config before watching memory

## Testing
- `pip install -q -r requirements.txt` *(fails: Operation cancelled by user)*
- `PYTHONPATH=. pytest -q` *(fails to import modules)*

------
https://chatgpt.com/codex/tasks/task_e_6841545f1e848321a1d2011f13783865