### PR TITLE
Add scheduler support for periodic fine tuning

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -14,6 +14,7 @@ trainer:
   learning_rate: 1e-4
   num_epochs: 5
   self_improve_threshold: 100
+  self_improve_interval: 60   # New: minutes between periodic fine-tunes
 
 # ===== Logging =====
 logging:

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -1,0 +1,32 @@
+# src/scheduler.py
+
+import yaml
+from apscheduler.schedulers.background import BackgroundScheduler
+from trainer import Trainer
+
+
+def periodic_fine_tune(config_path: str = "configs/default.yaml"):
+    """Reads config, fine-tunes on the current memory buffer every X minutes."""
+    with open(config_path, "r") as f:
+        cfg = yaml.safe_load(f)
+
+    interval_minutes = cfg.get("trainer", {}).get("self_improve_interval", 60)
+    trainer = Trainer(config_path=config_path)
+
+    scheduler = BackgroundScheduler()
+    scheduler.add_job(
+        trainer.fine_tune, "interval", minutes=interval_minutes, next_run_time=None
+    )
+    scheduler.start()
+
+    print(f"[Scheduler] Scheduled fine-tune every {interval_minutes} minutes.")
+    try:
+        # Keep the scheduler thread alive indefinitely
+        scheduler._event.wait()
+    except (KeyboardInterrupt, SystemExit):
+        scheduler.shutdown()
+        print("[Scheduler] Shutdown complete.")
+
+
+if __name__ == "__main__":
+    periodic_fine_tune()


### PR DESCRIPTION
## Summary
- add periodic fine-tuning scheduler module
- support `self_improve_interval` config option

## Testing
- `PYTHONPATH=. pytest -q tests/test_agent.py` *(fails: ModuleNotFoundError: No module named 'memory')*

------
https://chatgpt.com/codex/tasks/task_e_6841565b082c8321a30b70fe674b3bf8