### PR TITLE
Add tests for core modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+SRC_DIR = os.path.join(ROOT_DIR, 'src')
+for path in (ROOT_DIR, SRC_DIR):
+    if path not in sys.path:
+        sys.path.insert(0, path)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,8 +1,22 @@
-import pytest
+from types import SimpleNamespace
 from src.agent import Agent
+import requests
 
-def test_agent_responds():
+class DummyResponse:
+    def __init__(self, text="hi"):
+        self.status_code = 200
+        self._text = text
+    def json(self):
+        return {"response": self._text}
+    @property
+    def text(self):
+        return self._text
+
+
+def test_agent_responds(monkeypatch):
+    def fake_post(url, json):
+        return DummyResponse("pong")
+    monkeypatch.setattr(requests, "post", fake_post)
     agent = Agent(config_path="configs/default.yaml")
     resp = agent.respond("Test ping")
-    assert isinstance(resp, str)
-    assert len(resp) > 0
+    assert resp == "pong"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,26 @@
+import sys
+from src import cli
+
+called = {}
+
+class DummyAgent:
+    def __init__(self):
+        pass
+    def save_memory(self):
+        pass
+    def respond(self, text):
+        return "reply"
+
+class DummyTrainer:
+    def __init__(self):
+        called['created'] = True
+    def fine_tune(self):
+        called['fine_tune'] = True
+
+
+def test_cli_train(monkeypatch):
+    monkeypatch.setattr(cli, "Agent", DummyAgent)
+    monkeypatch.setattr(cli, "Trainer", DummyTrainer)
+    monkeypatch.setattr(sys, "argv", ["prog", "--train"])
+    cli.main()
+    assert called.get('fine_tune')

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,30 @@
+import os
+import shutil
+from src.memory import Memory
+
+
+def test_memory_add_and_limit(tmp_path):
+    mem_dir = tmp_path / "mem"
+    m = Memory(max_size=2, storage_path=str(mem_dir))
+
+    m.add({"role": "user", "text": "hi"})
+    m.add({"role": "assistant", "text": "there"})
+    # buffer should have two entries
+    assert len(m.buffer) == 2
+
+    # Adding another entry should drop the oldest
+    m.add({"role": "user", "text": "again"})
+    assert len(m.buffer) == 2
+    assert m.buffer[0]["text"] == "there"
+
+
+def test_memory_save(tmp_path):
+    mem_dir = tmp_path / "memsave"
+    m = Memory(max_size=2, storage_path=str(mem_dir))
+    m.add({"role": "user", "text": "hi"})
+    m.add({"role": "assistant", "text": "bye"})
+
+    m.save()
+    files = list(mem_dir.iterdir())
+    assert len(files) == 1
+    assert files[0].name.startswith("memory_") and files[0].suffix == ".json"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,40 @@
+from src import scheduler as sched_module
+
+class DummyTrainer:
+    def __init__(self):
+        self.fine_tune_called = False
+    def fine_tune(self):
+        self.fine_tune_called = True
+
+class DummyEvent:
+    def wait(self):
+        raise KeyboardInterrupt
+
+class DummyScheduler:
+    def __init__(self):
+        self.jobs = []
+        self.started = False
+        self._event = DummyEvent()
+    def add_job(self, func, trigger, minutes=None, next_run_time=None):
+        self.jobs.append((func, trigger, minutes, next_run_time))
+    def start(self):
+        self.started = True
+    def shutdown(self):
+        self.started = False
+
+
+def test_periodic_fine_tune(monkeypatch):
+    trainer = DummyTrainer()
+    created = {}
+    def scheduler_factory():
+        created['sched'] = DummyScheduler()
+        return created['sched']
+
+    monkeypatch.setattr(sched_module, "Trainer", lambda config_path="": trainer)
+    monkeypatch.setattr(sched_module, "BackgroundScheduler", scheduler_factory)
+
+    sched_module.periodic_fine_tune(config_path="configs/default.yaml")
+
+    sched = created['sched']
+    assert not sched.started  # should be shutdown
+    assert len(sched.jobs) == 1

--- a/tests/test_self_improve.py
+++ b/tests/test_self_improve.py
@@ -1,0 +1,16 @@
+from src.self_improve import MemoryHandler
+
+class DummyTrainer:
+    def __init__(self):
+        self.memory = type('M', (), {'buffer': []})()
+        self.fine_tune_called = False
+    def fine_tune(self):
+        self.fine_tune_called = True
+
+
+def test_memory_handler_triggers():
+    trainer = DummyTrainer()
+    trainer.memory.buffer.extend([1, 2])
+    handler = MemoryHandler(trainer=trainer, threshold=2)
+    handler.on_created(None)
+    assert trainer.fine_tune_called

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,0 +1,18 @@
+from src.trainer import Trainer
+
+
+def test_trainer_init():
+    t = Trainer(config_path="configs/default.yaml")
+    assert t.batch_size == 32
+    # learning_rate comes from YAML as a string
+    assert str(t.learning_rate) == "1e-4"
+    assert t.num_epochs == 5
+    assert hasattr(t, "memory")
+
+
+def test_trainer_fine_tune(capsys):
+    t = Trainer(config_path="configs/default.yaml")
+    t.memory.add({"role": "user", "text": "hi"})
+    t.fine_tune()
+    captured = capsys.readouterr()
+    assert "Trainer stub" in captured.out or "No memory" in captured.out


### PR DESCRIPTION
## Summary
- add pytest configuration for src imports
- create unit tests for agent, memory, trainer, scheduler, self-improve and CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415a0062788321baf279d5059e5c84