### PR TITLE
Add env and training tests

### DIFF
--- a/tests/test_saias_env.py
+++ b/tests/test_saias_env.py
@@ -1,0 +1,57 @@
+import numpy as np
+from src.envs import saias_env
+
+
+class DummyMemory:
+    def __init__(self):
+        self.buffer = []
+        self.max_size = 10
+
+
+class DummyAgent:
+    def __init__(self, config_path=""):
+        self.memory = DummyMemory()
+        self.respond_called = False
+
+    def respond(self, text):
+        self.respond_called = True
+        return "ok"
+
+
+class DummyTrainer:
+    def __init__(self, config_path=""):
+        self.fine_tune_called = False
+
+    def fine_tune(self):
+        self.fine_tune_called = True
+
+
+def test_saias_env_reset_and_step(monkeypatch):
+    monkeypatch.setattr(saias_env, "Agent", DummyAgent)
+    monkeypatch.setattr(saias_env, "Trainer", DummyTrainer)
+
+    env = saias_env.SaiasEnv(max_steps=3, state_size=4)
+    state, info = env.reset()
+
+    assert isinstance(state, np.ndarray)
+    assert state.shape == (4,)
+    assert info == {}
+
+    # first action: no-op
+    state, reward, done, _ = env.step(0)
+    assert state.shape == (4,)
+    assert reward == 0.0
+    assert done is False
+
+    # second action: fine_tune
+    state, reward, done, _ = env.step(1)
+    assert env.trainer.fine_tune_called
+    assert reward == 1.0
+    assert done is False
+
+    # third action: respond
+    state, reward, done, _ = env.step(2)
+    assert env.agent.respond_called
+    assert reward == -0.1
+    assert done is True
+

--- a/tests/test_train_ppo.py
+++ b/tests/test_train_ppo.py
@@ -1,0 +1,41 @@
+import os
+import gym
+
+import train_ppo
+
+
+class DummyEnv(gym.Env):
+    def __init__(self):
+        super().__init__()
+        self.action_space = gym.spaces.Discrete(1)
+        self.observation_space = gym.spaces.Box(low=0, high=1, shape=(1,), dtype=float)
+
+    def reset(self, seed=None, options=None):
+        return [0.0], {}
+
+    def step(self, action):
+        return [0.0], 0.0, True, {}
+
+
+class DummyModel:
+    def __init__(self, policy, env, **kwargs):
+        DummyModel.init_called = True
+
+    def learn(self, total_timesteps):
+        DummyModel.learn_called = total_timesteps
+
+    def save(self, path):
+        DummyModel.save_path = path
+
+
+def test_train_ppo_invoked(monkeypatch, tmp_path):
+    monkeypatch.setattr(train_ppo, "SaiasEnv", lambda config_path="configs/default.yaml": DummyEnv())
+    monkeypatch.setattr(train_ppo, "PPO", DummyModel)
+    monkeypatch.chdir(tmp_path)
+
+    train_ppo.main()
+
+    assert getattr(DummyModel, "init_called", False)
+    assert getattr(DummyModel, "learn_called", False)
+    assert getattr(DummyModel, "save_path", None) is not None
+


### PR DESCRIPTION
## Summary
- test SaiasEnv `reset()` and `step()` for all actions
- verify `train_ppo.main()` uses PPO by monkeypatching a dummy class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684171ad9f9c8321a1923ddc1296f55c