### PR TITLE
Update .gitignore for Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 memory_store/
 ppo_logs/
+__pycache__/
+.pytest_cache/
+*.py[cod]
+.env
+.venv
+


### PR DESCRIPTION
## Summary
- ignore common Python cache and environment directories

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684176d4e594832187d400456a2a08db