### PR TITLE
Add flake8 and CI, cleanup imports

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8
+      - name: Lint
+        run: flake8 .
+      - name: Test
+        run: pytest -q

--- a/src/self_improve.py
+++ b/src/self_improve.py
@@ -1,5 +1,4 @@
 import time
-import threading
 import yaml
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler


### PR DESCRIPTION
## Summary
- remove unused threading import from `self_improve`
- enforce flake8 settings via `.flake8`
- run flake8 and pytest in CI using GitHub Actions

## Testing
- `flake8 | head`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_684190c7779c83219a68e2a5ac8bc20a