### PR TITLE
Improve install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Additional modules:
    pip install -r requirements.txt
    pip install -e .        # install the src package
    ```
+   If you skip the editable install step, Python will not find the internal
+   modules and running scripts such as `train_ppo.py` can raise
+   `ModuleNotFoundError` errors.
 4. Launch the CLI:
    ```bash
    python src/cli.py [--train | --self-improve]


### PR DESCRIPTION
## Summary
- mention editable install requirement to prevent ModuleNotFoundError

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src' and other missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68419d1a5db08321b9e94e724fa5ad02