### PR TITLE
Fix gymnasium compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pytest
 requests
 watchdog
 apscheduler
-gym
+gymnasium
 stable-baselines3

--- a/src/envs/saias_env.py
+++ b/src/envs/saias_env.py
@@ -1,4 +1,4 @@
-import gym
+import gymnasium as gym
 import numpy as np
 
 from ..agent import Agent
@@ -6,7 +6,7 @@ from ..trainer import Trainer
 
 
 class SaiasEnv(gym.Env):
-    """Simple gym environment for controlling the SaiAS agent."""
+    """Simple Gymnasium environment for controlling the SaiAS agent."""
 
     def __init__(self, config_path: str = "configs/default.yaml", max_steps: int = 100, state_size: int = 128):
         super().__init__()
@@ -54,9 +54,10 @@ class SaiasEnv(gym.Env):
 
         self.state = self._get_state()
         self.current_step += 1
-        done = self.current_step >= self.max_steps
+        terminated = self.current_step >= self.max_steps
+        truncated = False
         info = {}
-        return self.state, reward, done, info
+        return self.state, reward, terminated, truncated, info
 
     def render(self):
         print(f"Step: {self.current_step}, State[0]: {self.state[0]:.3f}")

--- a/tests/test_saias_env.py
+++ b/tests/test_saias_env.py
@@ -38,20 +38,23 @@ def test_saias_env_reset_and_step(monkeypatch):
     assert info == {}
 
     # first action: no-op
-    state, reward, done, _ = env.step(0)
+    state, reward, done, truncated, _ = env.step(0)
     assert state.shape == (4,)
     assert reward == 0.0
     assert done is False
+    assert truncated is False
 
     # second action: fine_tune
-    state, reward, done, _ = env.step(1)
+    state, reward, done, truncated, _ = env.step(1)
     assert env.trainer.fine_tune_called
     assert reward == 1.0
     assert done is False
+    assert truncated is False
 
     # third action: respond
-    state, reward, done, _ = env.step(2)
+    state, reward, done, truncated, _ = env.step(2)
     assert env.agent.respond_called
     assert reward == -0.1
     assert done is True
+    assert truncated is False
 

--- a/tests/test_train_ppo.py
+++ b/tests/test_train_ppo.py
@@ -1,5 +1,5 @@
 import os
-import gym
+import gymnasium as gym
 
 import train_ppo
 
@@ -14,7 +14,7 @@ class DummyEnv(gym.Env):
         return [0.0], {}
 
     def step(self, action):
-        return [0.0], 0.0, True, {}
+        return [0.0], 0.0, True, False, {}
 
 
 class DummyModel:

--- a/train_ppo.py
+++ b/train_ppo.py
@@ -1,5 +1,5 @@
 import os
-import gym
+import gymnasium as gym
 import torch
 from stable_baselines3 import PPO
 from stable_baselines3.common.vec_env import DummyVecEnv


### PR DESCRIPTION
## Summary
- update to `gymnasium` since latest `stable-baselines3` expects it
- adjust `SaiasEnv` for the new API
- update unit tests for the `gymnasium` API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for src/numpy/torch/gymnasium)*

------
https://chatgpt.com/codex/tasks/task_e_68419ebbe7308321ba6530490c5b4446