### PR TITLE
Link trainer and agent memory for SaiasEnv

### DIFF
--- a/tests/test_saias_env.py
+++ b/tests/test_saias_env.py
@@ -47,9 +47,13 @@ def test_saias_env_reset_and_step(monkeypatch):
     # second action: fine_tune
     state, reward, done, truncated, _ = env.step(1)
     assert env.trainer.fine_tune_called
+    assert env.agent.respond_called
     assert reward == 1.0
     assert done is False
     assert truncated is False
+
+    # reset flag to verify that action 2 triggers another respond call
+    env.agent.respond_called = False
 
     # third action: respond
     state, reward, done, truncated, _ = env.step(2)


### PR DESCRIPTION
## Summary
- share memory buffer between `Agent` and `Trainer`
- ensure training step adds a prompt/response pair if none exists
- store responses so trainer memory grows when responding
- adjust environment test for new behaviour

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a9255b9c8321bf36feb6668cf2a7